### PR TITLE
details card

### DIFF
--- a/templates/movies/detail.html.twig
+++ b/templates/movies/detail.html.twig
@@ -1,0 +1,15 @@
+{% extends 'base.html.twig' %}
+
+{% block title %}Details du film{% endblock %}
+
+{% block body %}
+    <div class="movies">
+        <div class="movie">
+            <h2>{{ details.title }} <br> {{ details.release_date }} <br> {{ details.runtime }}min</h2>
+            <img src="https://image.tmdb.org/t/p/w500{{ details.poster_path }}" alt="{{ details.title }}">
+            <p>{{ details.overview }}</p>
+            <p>Langue d'origine : {{ details.original_language }}</p>
+            <p>{{ details.budget }} {{ details.revenue }}</p>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
This pull request includes a new template for displaying movie details in the `templates/movies/detail.html.twig` file. The template extends the base layout and includes blocks for the title and body content.

Changes in the movie details template:

* [`templates/movies/detail.html.twig`](diffhunk://#diff-8327e2cd34f0ea45875f0c7be6f2dbd52bda9fffe4e7539302079f9cece2ef85R1-R15): Added a new template that extends `base.html.twig`, includes a title block with "Details du film", and a body block that displays movie details such as title, release date, runtime, poster image, overview, original language, budget, and revenue.