### PR TITLE
redirect on search

### DIFF
--- a/templates/components/nav.html.twig
+++ b/templates/components/nav.html.twig
@@ -6,7 +6,7 @@
         <p class="text-center text-gray-300 text-lg">Découvrez tous les films à l'affiche</p>
     </div>
     <section aria-labelledby="movies-search" class="mb-10">
-        <form method="GET" class="max-w-2xl mx-auto">
+        <form action="{{ path('movie_list') }}" method="GET" class="max-w-2xl mx-auto">
             <div class="relative">
                 <div class="absolute inset-y-0 start-0 flex items-center ps-4 pointer-events-none">
                     <svg class="w-5 h-5 text-gray-400" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">


### PR DESCRIPTION
This pull request includes a change to the `templates/components/nav.html.twig` file. The change updates the form action to use the `movie_list` path.

* [`templates/components/nav.html.twig`](diffhunk://#diff-dd4e96015d6315d05accd1534c96fabc1e4426b54a31cbe3ea7ca860782cf9a7L9-R9): Updated the form action to use the `movie_list` path instead of the default GET method.